### PR TITLE
params は明示的に指定するものなので優先する

### DIFF
--- a/lib/omniauth/strategies/backlog.rb
+++ b/lib/omniauth/strategies/backlog.rb
@@ -37,14 +37,14 @@ module OmniAuth
       end
 
       def request_space_id
-        space_id = request.session['backlog_space_id'] || request.params['backlog_space_id']
+        space_id = request.params['backlog_space_id'] || request.session['backlog_space_id']
         request.session['backlog_space_id'] = space_id if space_id
 
         space_id
       end
 
       def request_site
-        site = request.session['backlog_space_host'] || request.params['backlog_space_host']
+        site = request.params['backlog_space_host'] || request.session['backlog_space_host']
         request.session['backlog_space_host'] = site if site
 
         site

--- a/test/omniauth/strategies/backlog_test.rb
+++ b/test/omniauth/strategies/backlog_test.rb
@@ -39,7 +39,26 @@ class TestOmniAuthBacklogWithParams < StrategyTestCase
   end
 end
 
-class TestOmniAuthBacklogWithSessions < StrategyTestCase
+class TestOmniAuthBacklogWithParamsAndSession < StrategyTestCase
+  def setup
+    super
+    @request = stub(params: { 'backlog_space_id' => 'testparams' }, session: { 'backlog_space_id' => 'testsession' })
+  end
+
+  def test_site_is_based_from_space_id
+    assert_equal 'https://testparams.backlog.com', strategy.client.site
+  end
+
+  def test_it_has_the_correct_authorize_url_with_site_from_options
+    assert_equal 'https://testparams.backlog.com/OAuth2AccessRequest.action', strategy.client.authorize_url
+  end
+
+  def test_it_has_the_correct_token_url_with_site_from_options
+    assert_equal 'https://testparams.backlog.com/api/v2/oauth2/token', strategy.client.token_url
+  end
+end
+
+class TestOmniAuthBacklogSpaceIdWithSessions < StrategyTestCase
   def setup
     super
     @request = stub(session: { 'backlog_space_id' => 'testsession'}, params: {})
@@ -58,7 +77,7 @@ class TestOmniAuthBacklogWithSessions < StrategyTestCase
   end
 end
 
-class TestOmniAuthBacklogWithSessions < StrategyTestCase
+class TestOmniAuthBacklogSpaceHostWithSessions < StrategyTestCase
   def setup
     super
     @request = stub(session: { 'backlog_space_host' => 'testsession.backlog.jp'}, params: {})


### PR DESCRIPTION
session を優先すると前に失敗したものを使い続けることになる